### PR TITLE
feat: add Gradle project setup for backend (task 0.1)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    id("org.springframework.boot") version "3.4.5"
+    id("io.spring.dependency-management") version "1.1.7"
+    id("nu.studer.jooq") version "9.0"
+    java
+}
+
+group = "dev.soupbase"
+version = "0.0.1-SNAPSHOT"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("software.amazon.awssdk:bom:2.28.0")
+        mavenBom("org.testcontainers:testcontainers-bom:1.20.1")
+    }
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.jooq:jooq:3.19.15")
+    implementation("org.flywaydb:flyway-core:10.21.0")
+    implementation("org.flywaydb:flyway-database-postgresql:10.21.0")
+    implementation("com.auth0:java-jwt:4.4.0")
+    implementation("software.amazon.awssdk:secretsmanager")
+    runtimeOnly("org.postgresql:postgresql")
+    jooqGenerator("org.postgresql:postgresql")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:junit-jupiter")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+jooq {
+    version.set("3.19.15")
+    // codegen configurations added in task 0.5
+}

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "soup-base"


### PR DESCRIPTION
Spring Boot 3.4, jOOQ 3.19, Flyway 10, Testcontainers, Java 21. Includes nu.studer.jooq plugin for codegen (configured in task 0.5). Virtual threads enabled via spring.threads.virtual.enabled=true (task 0.2).