### PR TITLE
feat: Spring Boot app entry point + Actuator health endpoint [0.2]

### DIFF
--- a/backend/src/main/java/dev/soupbase/SoupBaseApplication.java
+++ b/backend/src/main/java/dev/soupbase/SoupBaseApplication.java
@@ -1,0 +1,12 @@
+package dev.soupbase;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SoupBaseApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SoupBaseApplication.class, args);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  threads:
+    virtual:
+      enabled: true
+  datasource:
+    url: ${CONTROL_PLANE_DB_URL:jdbc:postgresql://localhost:5432/soupbase}
+    username: ${CONTROL_PLANE_DB_USERNAME:soupbase}
+    password: ${CONTROL_PLANE_DB_PASSWORD:soupbase}
+    driver-class-name: org.postgresql.Driver
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
Implements Phase 0, Task 0.2 from the implementation plan.

## Changes
- `SoupBaseApplication.java`: `@SpringBootApplication` entry point in `dev.soupbase` package
- `application.yml`: control-plane datasource via env vars, virtual threads enabled, Flyway configured, Actuator health at `/actuator/health` (NFR-OPS-002)

Closes #3

Generated with [Claude Code](https://claude.ai/code)