### PR TITLE
[1.1] UserService + UserRepository: find-or-create user by clerk_id

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -25,6 +25,7 @@ dependencyManagement {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/backend/src/main/java/dev/soupbase/api/AuthController.java
+++ b/backend/src/main/java/dev/soupbase/api/AuthController.java
@@ -1,0 +1,35 @@
+package dev.soupbase.api;
+
+import dev.soupbase.api.dto.SessionRequest;
+import dev.soupbase.api.dto.SessionResponse;
+import dev.soupbase.domain.UserService;
+import dev.soupbase.domain.model.User;
+import dev.soupbase.infra.ClerkPrincipal;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final UserService userService;
+
+    public AuthController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/session")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<SessionResponse> session(
+            @RequestBody @Valid SessionRequest request,
+            @AuthenticationPrincipal ClerkPrincipal principal) {
+        User user = userService.findOrCreate(principal.clerkId(), request.email());
+        return ResponseEntity.ok(SessionResponse.from(user));
+    }
+}

--- a/backend/src/main/java/dev/soupbase/api/dto/SessionRequest.java
+++ b/backend/src/main/java/dev/soupbase/api/dto/SessionRequest.java
@@ -1,0 +1,8 @@
+package dev.soupbase.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SessionRequest(
+        @NotBlank @Email String email
+) {}

--- a/backend/src/main/java/dev/soupbase/api/dto/SessionResponse.java
+++ b/backend/src/main/java/dev/soupbase/api/dto/SessionResponse.java
@@ -1,0 +1,17 @@
+package dev.soupbase.api.dto;
+
+import dev.soupbase.domain.model.User;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record SessionResponse(
+        UUID id,
+        String clerkId,
+        String email,
+        OffsetDateTime createdAt
+) {
+    public static SessionResponse from(User user) {
+        return new SessionResponse(user.id(), user.clerkId(), user.email(), user.createdAt());
+    }
+}

--- a/backend/src/main/java/dev/soupbase/config/JooqConfig.java
+++ b/backend/src/main/java/dev/soupbase/config/JooqConfig.java
@@ -2,6 +2,9 @@ package dev.soupbase.config;
 
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
+import org.jooq.conf.RenderNameCase;
+import org.jooq.conf.RenderQuotedNames;
+import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +16,9 @@ public class JooqConfig {
 
     @Bean
     public DSLContext dslContext(DataSource dataSource) {
-        return DSL.using(dataSource, SQLDialect.POSTGRES);
+        Settings settings = new Settings()
+                .withRenderQuotedNames(RenderQuotedNames.NEVER)
+                .withRenderNameCase(RenderNameCase.LOWER);
+        return DSL.using(dataSource, SQLDialect.POSTGRES, settings);
     }
 }

--- a/backend/src/main/java/dev/soupbase/config/JooqConfig.java
+++ b/backend/src/main/java/dev/soupbase/config/JooqConfig.java
@@ -1,0 +1,18 @@
+package dev.soupbase.config;
+
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class JooqConfig {
+
+    @Bean
+    public DSLContext dslContext(DataSource dataSource) {
+        return DSL.using(dataSource, SQLDialect.POSTGRES);
+    }
+}

--- a/backend/src/main/java/dev/soupbase/config/SecurityConfig.java
+++ b/backend/src/main/java/dev/soupbase/config/SecurityConfig.java
@@ -4,11 +4,13 @@ import dev.soupbase.infra.ClerkJwtFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -23,14 +25,15 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/health").permitAll()
-                        // Authentication is enforced by ClerkJwtFilter; authorization by @PreAuthorize.
                         .anyRequest().permitAll()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
                 .addFilterBefore(clerkJwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 
-    // Prevents Spring Boot from also registering the filter in the default servlet chain.
     @Bean
     public FilterRegistrationBean<ClerkJwtFilter> clerkJwtFilterRegistration(ClerkJwtFilter clerkJwtFilter) {
         FilterRegistrationBean<ClerkJwtFilter> registration = new FilterRegistrationBean<>(clerkJwtFilter);

--- a/backend/src/main/java/dev/soupbase/db/UserRepository.java
+++ b/backend/src/main/java/dev/soupbase/db/UserRepository.java
@@ -1,0 +1,39 @@
+package dev.soupbase.db;
+
+import dev.soupbase.domain.model.User;
+import dev.soupbase.db.generated.tables.records.UsersRecord;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.Objects;
+
+import static dev.soupbase.db.generated.Tables.USERS;
+
+@Repository
+public class UserRepository {
+
+    private final DSLContext dsl;
+
+    public UserRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    public User findOrCreate(String clerkId, String email) {
+        dsl.insertInto(USERS)
+                .columns(USERS.CLERK_ID, USERS.EMAIL)
+                .values(clerkId, email)
+                .onConflictDoNothing()
+                .execute();
+
+        return toUser(Objects.requireNonNull(
+                dsl.selectFrom(USERS)
+                        .where(USERS.CLERK_ID.eq(clerkId))
+                        .fetchOne(),
+                "User not found after insert: " + clerkId
+        ));
+    }
+
+    private User toUser(UsersRecord r) {
+        return new User(r.getId(), r.getClerkId(), r.getEmail(), r.getCreatedAt(), r.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/dev/soupbase/domain/UserService.java
+++ b/backend/src/main/java/dev/soupbase/domain/UserService.java
@@ -1,0 +1,19 @@
+package dev.soupbase.domain;
+
+import dev.soupbase.db.UserRepository;
+import dev.soupbase.domain.model.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User findOrCreate(String clerkId, String email) {
+        return userRepository.findOrCreate(clerkId, email);
+    }
+}

--- a/backend/src/main/java/dev/soupbase/domain/model/User.java
+++ b/backend/src/main/java/dev/soupbase/domain/model/User.java
@@ -1,0 +1,12 @@
+package dev.soupbase.domain.model;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record User(
+        UUID id,
+        String clerkId,
+        String email,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {}

--- a/backend/src/test/java/dev/soupbase/IntegrationTestBase.java
+++ b/backend/src/test/java/dev/soupbase/IntegrationTestBase.java
@@ -1,0 +1,83 @@
+package dev.soupbase;
+
+import dev.soupbase.infra.ClerkJwtFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import dev.soupbase.infra.ClerkPrincipal;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+public abstract class IntegrationTestBase {
+
+    private static final String TEST_TOKEN_PREFIX = "Bearer test-user-";
+
+    @Container
+    static final PostgreSQLContainer<?> controlPlane = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("soupbase_test")
+            .withUsername("soupbase")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", controlPlane::getJdbcUrl);
+        registry.add("spring.datasource.username", controlPlane::getUsername);
+        registry.add("spring.datasource.password", controlPlane::getPassword);
+        registry.add("clerk.jwks-url", () -> "https://test.clerk.dev/.well-known/jwks.json");
+        registry.add("clerk.issuer", () -> "https://test.clerk.dev");
+    }
+
+    @MockBean
+    ClerkJwtFilter clerkJwtFilter;
+
+    @Autowired
+    protected TestRestTemplate restTemplate;
+
+    @BeforeEach
+    void configureFakeAuth() throws Exception {
+        doAnswer(invocation -> {
+            HttpServletRequest request = (HttpServletRequest) invocation.getArgument(0);
+            FilterChain chain = invocation.getArgument(2);
+
+            String header = request.getHeader("Authorization");
+            if (header != null && header.startsWith(TEST_TOKEN_PREFIX)) {
+                String clerkId = header.substring(TEST_TOKEN_PREFIX.length());
+                ClerkPrincipal principal = new ClerkPrincipal(clerkId);
+                SecurityContextHolder.getContext().setAuthentication(
+                        new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+            } else {
+                SecurityContextHolder.clearContext();
+            }
+
+            chain.doFilter(
+                    invocation.getArgument(0, ServletRequest.class),
+                    invocation.getArgument(1, ServletResponse.class));
+            return null;
+        }).when(clerkJwtFilter).doFilter(any(), any(), any());
+    }
+
+    protected static String bearerToken(String clerkId) {
+        return TEST_TOKEN_PREFIX + clerkId;
+    }
+}

--- a/backend/src/test/java/dev/soupbase/api/AuthControllerApiTest.java
+++ b/backend/src/test/java/dev/soupbase/api/AuthControllerApiTest.java
@@ -1,0 +1,68 @@
+package dev.soupbase.api;
+
+import dev.soupbase.IntegrationTestBase;
+import dev.soupbase.api.dto.SessionRequest;
+import dev.soupbase.api.dto.SessionResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthControllerApiTest extends IntegrationTestBase {
+
+    private static final String CLERK_ID = "user_test_abc123";
+    private static final String EMAIL = "test@example.com";
+
+    @Test
+    void session_withValidAuth_createsAndReturnsUserProfile() {
+        ResponseEntity<SessionResponse> response = postSession(CLERK_ID, EMAIL);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        SessionResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.clerkId()).isEqualTo(CLERK_ID);
+        assertThat(body.email()).isEqualTo(EMAIL);
+        assertThat(body.id()).isNotNull();
+        assertThat(body.createdAt()).isNotNull();
+    }
+
+    @Test
+    void session_calledTwice_isIdempotentAndReturnsExistingRecord() {
+        ResponseEntity<SessionResponse> first = postSession(CLERK_ID + "_idem", EMAIL);
+        ResponseEntity<SessionResponse> second = postSession(CLERK_ID + "_idem", EMAIL);
+
+        assertThat(first.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(second.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        SessionResponse firstBody = first.getBody();
+        SessionResponse secondBody = second.getBody();
+        assertThat(firstBody).isNotNull();
+        assertThat(secondBody).isNotNull();
+        assertThat(secondBody.id()).isEqualTo(firstBody.id());
+        assertThat(secondBody.clerkId()).isEqualTo(firstBody.clerkId());
+        assertThat(secondBody.createdAt()).isEqualTo(firstBody.createdAt());
+    }
+
+    @Test
+    void session_withoutAuth_returns401() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<SessionRequest> entity = new HttpEntity<>(new SessionRequest(EMAIL), headers);
+
+        ResponseEntity<Void> response = restTemplate.postForEntity("/api/auth/session", entity, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    private ResponseEntity<SessionResponse> postSession(String clerkId, String email) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", bearerToken(clerkId));
+        HttpEntity<SessionRequest> entity = new HttpEntity<>(new SessionRequest(email), headers);
+        return restTemplate.postForEntity("/api/auth/session", entity, SessionResponse.class);
+    }
+}


### PR DESCRIPTION
Fixes DSLContext bean and implements FR-AU-002: POST /api/auth/session creates a user record on first sign-in (keyed by Clerk userId) and returns the existing record on subsequent calls.

Root cause of previous test failures: NoSuchBeanDefinitionException for DSLContext — fixed by adding JooqConfig.java.

Closes #22

Generated with [Claude Code](https://claude.ai/code)