### PR TITLE
feat: Task 1.3 — DatabaseService + DatabaseRepository

### DIFF
--- a/backend/src/main/java/dev/soupbase/db/DatabaseRepository.java
+++ b/backend/src/main/java/dev/soupbase/db/DatabaseRepository.java
@@ -1,0 +1,69 @@
+package dev.soupbase.db;
+
+import dev.soupbase.domain.model.Database;
+import dev.soupbase.domain.model.DatabaseStatus;
+import dev.soupbase.db.generated.tables.records.DatabasesRecord;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static dev.soupbase.db.generated.Tables.DATABASES;
+import static dev.soupbase.db.generated.enums.DatabaseStatus.PROVISIONING;
+
+@Repository
+public class DatabaseRepository {
+
+    private final DSLContext dsl;
+
+    public DatabaseRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    public int countNonDeletedByUserId(UUID userId) {
+        return dsl.selectCount()
+                .from(DATABASES)
+                .where(DATABASES.USER_ID.eq(userId))
+                .and(DATABASES.STATUS.ne(dev.soupbase.db.generated.enums.DatabaseStatus.DELETED))
+                .fetchOne(0, int.class);
+    }
+
+    public boolean existsByUserIdAndName(UUID userId, String name) {
+        return dsl.fetchExists(
+                dsl.selectFrom(DATABASES)
+                        .where(DATABASES.USER_ID.eq(userId))
+                        .and(DATABASES.NAME.eq(name))
+        );
+    }
+
+    public Database insert(UUID id, UUID userId, String name, String pgDatabaseName,
+                           String pgUsername, String pgPasswordHash) {
+        DatabasesRecord record = Objects.requireNonNull(
+                dsl.insertInto(DATABASES)
+                        .columns(DATABASES.ID, DATABASES.USER_ID, DATABASES.NAME,
+                                DATABASES.PG_DATABASE_NAME, DATABASES.PG_USERNAME,
+                                DATABASES.PG_PASSWORD_HASH, DATABASES.STATUS)
+                        .values(id, userId, name, pgDatabaseName, pgUsername, pgPasswordHash, PROVISIONING)
+                        .returning()
+                        .fetchOne(),
+                "Insert did not return a record for database id: " + id
+        );
+        return toDatabase(record);
+    }
+
+    private static Database toDatabase(DatabasesRecord r) {
+        return new Database(
+                r.getId(),
+                r.getUserId(),
+                r.getName(),
+                r.getPgDatabaseName(),
+                r.getPgUsername(),
+                r.getPgPasswordHash(),
+                DatabaseStatus.valueOf(r.getStatus().getLiteral()),
+                r.getFailureReason(),
+                r.getCreatedAt(),
+                r.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/dev/soupbase/domain/DatabaseService.java
+++ b/backend/src/main/java/dev/soupbase/domain/DatabaseService.java
@@ -1,0 +1,107 @@
+package dev.soupbase.domain;
+
+import dev.soupbase.db.DatabaseRepository;
+import dev.soupbase.domain.model.Database;
+import dev.soupbase.domain.model.User;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Service
+public class DatabaseService {
+
+    private static final int MAX_DATABASES = 3;
+    private static final int MAX_NAME_LENGTH = 40;
+    private static final Pattern VALID_NAME = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-]*$");
+
+    private static final String[] ADJECTIVES = {
+        "amber", "brave", "calm", "dark", "eager",
+        "fast", "gold", "jade", "keen", "lime",
+        "mint", "navy", "pale", "rose", "ruby",
+        "sage", "sky", "teal", "warm", "wild"
+    };
+
+    private static final String[] NOUNS = {
+        "atlas", "bloom", "cedar", "coral", "dusk",
+        "ember", "fern", "grove", "haven", "iris",
+        "lark", "mesa", "nile", "opal", "pine",
+        "quill", "reed", "tide", "vale", "wren"
+    };
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final PasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();
+
+    private final DatabaseRepository databaseRepository;
+
+    public DatabaseService(DatabaseRepository databaseRepository) {
+        this.databaseRepository = databaseRepository;
+    }
+
+    public Result<Database> createDatabase(User user, String requestedName) {
+        int count = databaseRepository.countNonDeletedByUserId(user.id());
+        if (count >= MAX_DATABASES) {
+            return new Result.Err<>("DATABASE_LIMIT_REACHED", "Maximum of 3 databases allowed per user");
+        }
+
+        String name;
+        if (requestedName == null || requestedName.isBlank()) {
+            name = generateName();
+        } else {
+            name = requestedName.strip();
+            if (name.length() > MAX_NAME_LENGTH) {
+                return new Result.Err<>("INVALID_NAME", "Name must be at most 40 characters");
+            }
+            if (!VALID_NAME.matcher(name).matches()) {
+                return new Result.Err<>("INVALID_NAME", "Name must contain only alphanumeric characters and hyphens");
+            }
+        }
+
+        if (databaseRepository.existsByUserIdAndName(user.id(), name)) {
+            return new Result.Err<>("DUPLICATE_NAME", "A database with this name already exists");
+        }
+
+        UUID dbId = UUID.randomUUID();
+        String userHash = computeUserHash(user.clerkId());
+        String shortId = dbId.toString().replace("-", "").substring(0, 8);
+        String pgDatabaseName = "sb_" + userHash + "_" + shortId;
+        String pgUsername = "sb_u_" + userHash + "_" + shortId;
+
+        String password = generatePassword();
+        String pgPasswordHash = PASSWORD_ENCODER.encode(password);
+
+        Database database = databaseRepository.insert(
+                dbId, user.id(), name, pgDatabaseName, pgUsername, pgPasswordHash);
+
+        return new Result.Ok<>(database);
+    }
+
+    private static String generateName() {
+        String adj = ADJECTIVES[RANDOM.nextInt(ADJECTIVES.length)];
+        String noun = NOUNS[RANDOM.nextInt(NOUNS.length)];
+        return "db-" + adj + "-" + noun;
+    }
+
+    private static String generatePassword() {
+        byte[] bytes = new byte[24];
+        RANDOM.nextBytes(bytes);
+        return HexFormat.of().formatHex(bytes);
+    }
+
+    private static String computeUserHash(String clerkId) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] hash = md.digest(clerkId.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash).substring(0, 6);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 unavailable", e);
+        }
+    }
+}

--- a/backend/src/main/java/dev/soupbase/domain/Result.java
+++ b/backend/src/main/java/dev/soupbase/domain/Result.java
@@ -1,0 +1,6 @@
+package dev.soupbase.domain;
+
+public sealed interface Result<T> permits Result.Ok, Result.Err {
+    record Ok<T>(T value) implements Result<T> {}
+    record Err<T>(String code, String message) implements Result<T> {}
+}

--- a/backend/src/main/java/dev/soupbase/domain/model/Database.java
+++ b/backend/src/main/java/dev/soupbase/domain/model/Database.java
@@ -1,0 +1,17 @@
+package dev.soupbase.domain.model;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record Database(
+        UUID id,
+        UUID userId,
+        String name,
+        String pgDatabaseName,
+        String pgUsername,
+        String pgPasswordHash,
+        DatabaseStatus status,
+        String failureReason,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {}

--- a/backend/src/main/java/dev/soupbase/domain/model/DatabaseStatus.java
+++ b/backend/src/main/java/dev/soupbase/domain/model/DatabaseStatus.java
@@ -1,0 +1,5 @@
+package dev.soupbase.domain.model;
+
+public enum DatabaseStatus {
+    PROVISIONING, ACTIVE, DELETING, DELETED, FAILED
+}


### PR DESCRIPTION
Implements Task 1.3 (FR-DB-001): DatabaseService and DatabaseRepository for database record creation.

Enforces the 3-database limit per user, unique name per user, name validation (max 40 chars, alphanumeric + hyphens), auto-generated names, and creates records with initial PROVISIONING status.

Also introduces the `Result<T>` sealed interface and Database domain model types used across the domain layer.

Closes #24

Generated with [Claude Code](https://claude.ai/code)